### PR TITLE
Add type specialization for performance

### DIFF
--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -9,10 +9,13 @@ struct PeriodicBox{NDIMS, ELTYPE}
     end
 end
 
-@inline function for_particle_neighbor(f, system_coords, neighbor_coords,
-                                       neighborhood_search;
-                                       particles = axes(system_coords, 2),
-                                       parallel = true)
+# The type annotation is to make Julia specialize on the type of the function.
+# Otherwise, unspecialized code will cause a lot of allocations
+# and heavily impact performance.
+# See https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing
+function for_particle_neighbor(f::T, system_coords, neighbor_coords, neighborhood_search;
+                               particles = axes(system_coords, 2),
+                               parallel = true) where {T}
     for_particle_neighbor(f, system_coords, neighbor_coords, neighborhood_search, particles,
                           Val(parallel))
 end


### PR DESCRIPTION
Previously, we circumvented this by making everything inline.

@sloede @ranocha which is the better approach? Inlining everything so that there is no non-inlined function where Julia avoids specialization, or this PR?