### PR TITLE
Change NHS API to update with both systems' coordinates

### DIFF
--- a/src/TrixiNeighborhoodSearch.jl
+++ b/src/TrixiNeighborhoodSearch.jl
@@ -13,6 +13,6 @@ include("grid_nhs.jl")
 
 export for_particle_neighbor
 export TrivialNeighborhoodSearch, GridNeighborhoodSearch
-export initialize!, update!
+export initialize!, update!, initialize_grid!, update_grid!
 
 end # module TrixiNeighborhoodSearch

--- a/src/grid_nhs.jl
+++ b/src/grid_nhs.jl
@@ -166,12 +166,6 @@ function initialize_grid!(neighborhood_search::GridNeighborhoodSearch, coords_fu
     return neighborhood_search
 end
 
-function update!(neighborhood_search::GridNeighborhoodSearch, ::Nothing, ::Nothing;
-                 particles_moving = (true, true))
-    # No particle coordinates function -> don't update.
-    return neighborhood_search
-end
-
 function update!(neighborhood_search::GridNeighborhoodSearch,
                  x::AbstractMatrix, y::AbstractMatrix,
                  particles_moving = (true, true))

--- a/src/grid_nhs.jl
+++ b/src/grid_nhs.jl
@@ -142,10 +142,6 @@ function initialize_grid!(neighborhood_search::GridNeighborhoodSearch{NDIMS},
     initialize_grid!(neighborhood_search, i -> extract_svector(y, Val(NDIMS), i))
 end
 
-function initialize!(neighborhood_search::GridNeighborhoodSearch, coords_fun1, coords_fun2)
-    initialize_grid!(neighborhood_search, coords_fun2)
-end
-
 function initialize_grid!(neighborhood_search::GridNeighborhoodSearch, coords_fun)
     (; hashtable) = neighborhood_search
 
@@ -180,15 +176,6 @@ end
 function update_grid!(neighborhood_search::GridNeighborhoodSearch{NDIMS},
                       y::AbstractMatrix) where {NDIMS}
     update_grid!(neighborhood_search, i -> extract_svector(y, Val(NDIMS), i))
-end
-
-function update!(neighborhood_search::GridNeighborhoodSearch, coords_fun1, coords_fun2;
-                 particles_moving = (true, true))
-    # The coordinates of the first set of particles are irrelevant for this NHS.
-    # Only update when the second set is moving.
-    particles_moving[2] || return neighborhood_search
-
-    update_grid!(neighborhood_search, coords_fun2)
 end
 
 # Modify the existing hash table by moving particles into their new cells

--- a/src/grid_nhs.jl
+++ b/src/grid_nhs.jl
@@ -387,6 +387,6 @@ function copy_neighborhood_search(nhs::GridNeighborhoodSearch, search_radius, x,
 end
 
 # Create a copy of a neighborhood search but with a different search radius
-function copy_neighborhood_search(nhs::TrivialNeighborhoodSearch, search_radius, u)
+function copy_neighborhood_search(nhs::TrivialNeighborhoodSearch, search_radius, x, y)
     return nhs
 end

--- a/src/grid_nhs.jl
+++ b/src/grid_nhs.jl
@@ -371,7 +371,7 @@ end
 end
 
 # Create a copy of a neighborhood search but with a different search radius
-function copy_neighborhood_search(nhs::GridNeighborhoodSearch, search_radius, u)
+function copy_neighborhood_search(nhs::GridNeighborhoodSearch, search_radius, x, y)
     if nhs.periodic_box === nothing
         search = GridNeighborhoodSearch{ndims(nhs)}(search_radius, nparticles(nhs))
     else
@@ -381,7 +381,7 @@ function copy_neighborhood_search(nhs::GridNeighborhoodSearch, search_radius, u)
     end
 
     # Initialize neighborhood search
-    initialize!(search, u)
+    initialize!(search, x, y)
 
     return search
 end

--- a/src/grid_nhs.jl
+++ b/src/grid_nhs.jl
@@ -132,11 +132,6 @@ end
     return size(neighborhood_search.cell_buffer, 1)
 end
 
-function initialize!(neighborhood_search::GridNeighborhoodSearch, ::Nothing, ::Nothing)
-    # No particle coordinates function -> don't initialize.
-    return neighborhood_search
-end
-
 function initialize!(neighborhood_search::GridNeighborhoodSearch,
                      x::AbstractMatrix, y::AbstractMatrix)
     initialize_grid!(neighborhood_search, y)

--- a/src/grid_nhs.jl
+++ b/src/grid_nhs.jl
@@ -167,21 +167,21 @@ function initialize!(neighborhood_search::GridNeighborhoodSearch, coords_fun1, c
 end
 
 function update!(neighborhood_search::GridNeighborhoodSearch, ::Nothing, ::Nothing;
-                 particles_moving=(true, true))
+                 particles_moving = (true, true))
     # No particle coordinates function -> don't update.
     return neighborhood_search
 end
 
 function update!(neighborhood_search::GridNeighborhoodSearch{NDIMS},
                  x::AbstractMatrix, y::AbstractMatrix,
-                 particles_moving=(true, true)) where {NDIMS}
+                 particles_moving = (true, true)) where {NDIMS}
     update!(neighborhood_search, nothing, i -> extract_svector(y, Val(NDIMS), i),
-            particles_moving=particles_moving)
+            particles_moving = particles_moving)
 end
 
 # Modify the existing hash table by moving particles into their new cells
 function update!(neighborhood_search::GridNeighborhoodSearch, coords_fun1, coords_fun2;
-                 particles_moving=(true, true))
+                 particles_moving = (true, true))
     (; hashtable, cell_buffer, cell_buffer_indices, threaded_nhs_update) = neighborhood_search
 
     # Reset `cell_buffer` by moving all pointers to the beginning.
@@ -189,7 +189,8 @@ function update!(neighborhood_search::GridNeighborhoodSearch, coords_fun1, coord
 
     # Find all cells containing particles that now belong to another cell.
     # `collect` the keyset to be able to loop over it with `@threaded`.
-    mark_changed_cell!(neighborhood_search, hashtable, coords_fun2, Val(threaded_nhs_update))
+    mark_changed_cell!(neighborhood_search, hashtable, coords_fun2,
+                       Val(threaded_nhs_update))
 
     # This is needed to prevent lagging on macOS ARM.
     # See https://github.com/JuliaSIMD/Polyester.jl/issues/89

--- a/src/trivial_nhs.jl
+++ b/src/trivial_nhs.jl
@@ -77,7 +77,7 @@ end
 @inline initialize!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2) = search
 
 @inline function update!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2;
-                         particles_moving=(true, true))
+                         particles_moving = (true, true))
     return search
 end
 

--- a/src/trivial_nhs.jl
+++ b/src/trivial_nhs.jl
@@ -74,9 +74,9 @@ end
     return NDIMS
 end
 
-@inline initialize!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2) = search
+@inline initialize!(search::TrivialNeighborhoodSearch, x, y) = search
 
-@inline function update!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2;
+@inline function update!(search::TrivialNeighborhoodSearch, x, y;
                          particles_moving = (true, true))
     return search
 end

--- a/src/trivial_nhs.jl
+++ b/src/trivial_nhs.jl
@@ -74,6 +74,11 @@ end
     return NDIMS
 end
 
-@inline initialize!(search::TrivialNeighborhoodSearch, coords_fun) = search
-@inline update!(search::TrivialNeighborhoodSearch, coords_fun) = search
+@inline initialize!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2) = search
+
+@inline function update!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2;
+                         particles_moving=(true, true))
+    return search
+end
+
 @inline eachneighbor(coords, search::TrivialNeighborhoodSearch) = search.eachparticle

--- a/test/grid_nhs.jl
+++ b/test/grid_nhs.jl
@@ -29,7 +29,7 @@
         nhs1 = GridNeighborhoodSearch{2}(radius, nparticles)
 
         coords_fun(i) = coordinates1[:, i]
-        initialize!(nhs1, coords_fun)
+        initialize_grid!(nhs1, coords_fun)
 
         # Get each neighbor for `particle_position1`
         neighbors1 = sort(collect(TrixiNeighborhoodSearch.eachneighbor(particle_position1,
@@ -40,7 +40,7 @@
 
         # Update neighborhood search
         coords_fun2(i) = coordinates2[:, i]
-        update!(nhs1, coords_fun2)
+        update_grid!(nhs1, coords_fun2)
 
         # Get each neighbor for updated NHS
         neighbors2 = sort(collect(TrixiNeighborhoodSearch.eachneighbor(particle_position1,
@@ -55,7 +55,7 @@
 
         # Double search radius
         nhs2 = GridNeighborhoodSearch{2}(2 * radius, size(coordinates1, 2))
-        initialize!(nhs2, coords_fun)
+        initialize_grid!(nhs2, coords_fun)
 
         # Get each neighbor in double search radius
         neighbors4 = sort(collect(TrixiNeighborhoodSearch.eachneighbor(particle_position1,
@@ -65,7 +65,7 @@
         coordinates2 = coordinates1 .+ [0.4, -0.4]
 
         # Update neighborhood search
-        update!(nhs2, coords_fun2)
+        update_grid!(nhs2, coords_fun2)
 
         # Get each neighbor in double search radius
         neighbors5 = sort(collect(TrixiNeighborhoodSearch.eachneighbor(particle_position1,
@@ -102,7 +102,7 @@
         nhs1 = GridNeighborhoodSearch{3}(radius, nparticles)
 
         coords_fun(i) = coordinates1[:, i]
-        initialize!(nhs1, coords_fun)
+        initialize_grid!(nhs1, coords_fun)
 
         # Get each neighbor for `particle_position1`
         neighbors1 = sort(collect(TrixiNeighborhoodSearch.eachneighbor(particle_position1,
@@ -113,7 +113,7 @@
 
         # Update neighborhood search
         coords_fun2(i) = coordinates2[:, i]
-        update!(nhs1, coords_fun2)
+        update_grid!(nhs1, coords_fun2)
 
         # Get each neighbor for updated NHS
         neighbors2 = sort(collect(TrixiNeighborhoodSearch.eachneighbor(particle_position1,
@@ -148,7 +148,7 @@
                                             periodic_box_min_corner = [-0.1, -0.2],
                                             periodic_box_max_corner = [0.2, 0.4])
 
-            initialize!(nhs, coords)
+            initialize_grid!(nhs, coords)
 
             neighbors = [sort(collect(TrixiNeighborhoodSearch.eachneighbor(coords[:, i],
                                                                            nhs)))
@@ -187,7 +187,7 @@
                                             periodic_box_min_corner = [-0.1, -0.2],
                                             periodic_box_max_corner = [0.205, 0.43])
 
-            initialize!(nhs, coords)
+            initialize_grid!(nhs, coords)
 
             neighbors = [sort(collect(TrixiNeighborhoodSearch.eachneighbor(coords[:, i],
                                                                            nhs)))
@@ -234,7 +234,7 @@
                                             periodic_box_min_corner = [-1.5, 0.0],
                                             periodic_box_max_corner = [2.5, 3.0])
 
-            initialize!(nhs, coords)
+            initialize_grid!(nhs, coords)
 
             neighbors = [sort(unique(collect(TrixiNeighborhoodSearch.eachneighbor(coords[:,
                                                                                          i],
@@ -256,7 +256,7 @@
                                         periodic_box_min_corner = [-0.1, -0.2, 0.05],
                                         periodic_box_max_corner = [0.2, 0.4, 0.35])
 
-        initialize!(nhs, coords)
+        initialize_grid!(nhs, coords)
 
         neighbors = [sort(collect(TrixiNeighborhoodSearch.eachneighbor(coords[:, i], nhs)))
                      for i in 1:5]


### PR DESCRIPTION
With this PR, I pass both system's coordinates to the NHS, together with the information which of the coordinates are changing and which are static. The NHS can then decide if and what to update.

For example, the grid NHS doesn't need to update for fluid-boundary NHS. A neighborhood search that explicitly computes the neighbor lists will have to update them because the fluid particles are moving.