### PR TITLE
Improve GPU performance by changing the offset computation of the `FullGridCellList`

### DIFF
--- a/src/cell_lists/full_grid.jl
+++ b/src/cell_lists/full_grid.jl
@@ -97,9 +97,9 @@ end
     (; min_corner) = cell_list
 
     # Subtract `min_corner` to offset coordinates so that the min corner of the grid
-    # corresponds to the (1, 1) cell.
-    # Note that `min_corner == periodic_box.min_corner`, so we don't have to handle
-    # periodic boxes differently.
+    # corresponds to the (1, 1, 1) cell.
+    # Note that we use `min_corner == periodic_box.min_corner`, so we don't have to handle
+    # periodic boxes differently, as they also use 1-based indexing.
     return Tuple(floor_to_int.((coords .- min_corner) ./ cell_size)) .+ 1
 end
 

--- a/src/cell_lists/full_grid.jl
+++ b/src/cell_lists/full_grid.jl
@@ -55,21 +55,14 @@ function FullGridCellList(; min_corner, max_corner, search_radius = 0.0,
         cells = construct_backend(backend, 0, 0)
         linear_indices = nothing
 
-        # Misuse `min_cell` to store min and max corner for copying
-        min_cell = (min_corner, max_corner)
+        # Misuse `min_corner` to store min and max corner for copying
+        min_corner = (min_corner, max_corner)
     else
-        if periodicity
-            # Subtract `min_corner` because that's how the grid NHS works with periodicity
-            max_corner = max_corner .- min_corner
-            min_corner = min_corner .- min_corner
-        end
-
         # Note that we don't shift everything so that the first cell starts at `min_corner`.
         # The first cell is the cell containing `min_corner`, so we need to add one layer
         # in order for `max_corner` to be inside a cell.
         n_cells_per_dimension = ceil.(Int, (max_corner .- min_corner) ./ search_radius) .+ 1
         linear_indices = LinearIndices(Tuple(n_cells_per_dimension))
-        min_cell = Tuple(floor_to_int.(min_corner ./ search_radius))
 
         cells = construct_backend(backend, n_cells_per_dimension, max_points_per_cell)
     end
@@ -187,7 +180,7 @@ end
 
 function copy_cell_list(cell_list::FullGridCellList, search_radius, periodic_box)
     # Misuse `min_cell` to store min and max corner for copying
-    min_corner, max_corner = cell_list.min_cell
+    min_corner, max_corner = cell_list.min_corner
 
     return FullGridCellList(; min_corner, max_corner, search_radius,
                             periodicity = !isnothing(periodic_box),

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -405,16 +405,16 @@ end
 end
 
 @inline function cell_coords(coords, neighborhood_search)
-    (; periodic_box, cell_size) = neighborhood_search
+    (; periodic_box, cell_list, cell_size) = neighborhood_search
 
-    return cell_coords(coords, periodic_box, cell_size)
+    return cell_coords(coords, periodic_box, cell_list, cell_size)
 end
 
-@inline function cell_coords(coords, periodic_box::Nothing, cell_size)
+@inline function cell_coords(coords, periodic_box::Nothing, cell_list, cell_size)
     return Tuple(floor_to_int.(coords ./ cell_size))
 end
 
-@inline function cell_coords(coords, periodic_box, cell_size)
+@inline function cell_coords(coords, periodic_box, cell_list, cell_size)
     # Subtract `min_corner` to offset coordinates so that the min corner of the periodic
     # box corresponds to the (0, 0) cell of the NHS.
     # This way, there are no partial cells in the domain if the domain size is an integer

--- a/test/nhs_grid.jl
+++ b/test/nhs_grid.jl
@@ -57,12 +57,25 @@
         coords2 = [NaN, 0]
         coords3 = [typemax(Int) + 1.0, -typemax(Int) - 1.0]
 
-        @test PointNeighbors.cell_coords(coords1, nothing, (1.0, 1.0)) ==
+        @test PointNeighbors.cell_coords(coords1, nothing, nothing, (1.0, 1.0)) ==
               (typemax(Int), typemin(Int))
-        @test PointNeighbors.cell_coords(coords2, nothing, (1.0, 1.0)) ==
+        @test PointNeighbors.cell_coords(coords2, nothing, nothing, (1.0, 1.0)) ==
               (typemax(Int), 0)
-        @test PointNeighbors.cell_coords(coords3, nothing, (1.0, 1.0)) ==
+        @test PointNeighbors.cell_coords(coords3, nothing, nothing, (1.0, 1.0)) ==
               (typemax(Int), typemin(Int))
+
+        # The full grid cell list adds one to the coordinates to avoid zero-indexing.
+        # This corner case is not relevant, as `typemax` coordinates will always be out of
+        # bounds for the finite domain of the full grid cell list.
+        cell_list = FullGridCellList(min_corner = (0.0, 0.0), max_corner = (1.0, 1.0),
+                                     search_radius = 1.0)
+
+        @test PointNeighbors.cell_coords(coords1, nothing, cell_list, (1.0, 1.0)) ==
+              (typemax(Int), typemin(Int)) .+ 1
+        @test PointNeighbors.cell_coords(coords2, nothing, cell_list, (1.0, 1.0)) ==
+              (typemax(Int), 0) .+ 1
+        @test PointNeighbors.cell_coords(coords3, nothing, cell_list, (1.0, 1.0)) ==
+              (typemax(Int), typemin(Int)) .+ 1
     end
 
     @testset "Rectangular Point Cloud 2D" begin


### PR DESCRIPTION
Based on #49.

I basically changed what the commit says: "Subtract `min_corner` in `cell_coords` instead of subtracting `min_cell` in `getindex`".

Previously, `cell_coords` returned the absolute cell coordinates, then the neighbor cells around these were computed, and for each of those neighbor cells, the offset `min_cell` had to be subtracted.
Now, I subtract the `min_corner` in `cell_coordinates`, so that we don't have to do this for every neighboring cell.

On the CPU, the difference is small:
```
julia> plot_benchmarks(benchmark_wcsph, (118, 118, 118), 3)
new version
with 118x118x118 = 1643032 particles finished in 243.722 ms

first version
with 118x118x118 = 1643032 particles finished in 262.962 ms

new version
with 187x187x187 = 6539203 particles finished in 1.003 s

first version
with 187x187x187 = 6539203 particles finished in 1.062 s

new version
with 297x297x297 = 26198073 particles finished in 4.070 s

first version
with 297x297x297 = 26198073 particles finished in 4.284 s

julia> plot_benchmarks(benchmark_n_body, (118, 118, 118), 3)
new version
with 118x118x118 = 1643032 particles finished in 103.480 ms

first version
with 118x118x118 = 1643032 particles finished in 116.125 ms

new version
with 187x187x187 = 6539203 particles finished in 424.271 ms

first version
with 187x187x187 = 6539203 particles finished in 471.688 ms

new version
with 297x297x297 = 26198073 particles finished in 1.709 s

first version
with 297x297x297 = 26198073 particles finished in 1.897 s
```
On the GPU (RTX 3090), however, the difference is huge. Even for the real-life WCSPH benchmark:
```
julia> plot_benchmarks(benchmark_wcsph_gpu, (118, 118, 118), 3)
new version
with 118x118x118 = 1643032 particles finished in 252.205 ms

first version
with 118x118x118 = 1643032 particles finished in 405.049 ms

new version
with 187x187x187 = 6539203 particles finished in 1.003 s

first version
with 187x187x187 = 6539203 particles finished in 1.643 s

new version
with 297x297x297 = 26198073 particles finished in 3.972 s

first version
with 297x297x297 = 26198073 particles finished in 6.602 s

julia> plot_benchmarks(benchmark_n_body_gpu, (118, 118, 118), 3)
new version
with 118x118x118 = 1643032 particles finished in 85.513 ms

first version
with 118x118x118 = 1643032 particles finished in 135.293 ms

new version
with 187x187x187 = 6539203 particles finished in 338.926 ms

first version
with 187x187x187 = 6539203 particles finished in 536.936 ms

new version
with 297x297x297 = 26198073 particles finished in 1.352 s

first version
with 297x297x297 = 26198073 particles finished in 2.177 s
```