### PR TITLE
Store coordinates together with the points in a cell list

### DIFF
--- a/src/cell_lists/cell_lists.jl
+++ b/src/cell_lists/cell_lists.jl
@@ -1,4 +1,6 @@
-abstract type AbstractCellList end
+abstract type AbstractCellList{T} end
+
+Base.eltype(::AbstractCellList{T}) where {T} = T
 
 # For the `DictionaryCellList`, this is a `KeySet`, which has to be `collect`ed first to be
 # able to be used in a threaded loop.

--- a/src/cell_lists/dictionary.jl
+++ b/src/cell_lists/dictionary.jl
@@ -39,7 +39,7 @@ function push_cell!(cell_list::DictionaryCellList, cell, point)
     (; hashtable) = cell_list
 
     if haskey(hashtable, cell)
-        append!(hashtable[cell], point)
+        push!(hashtable[cell], point)
     else
         hashtable[cell] = [point]
     end

--- a/src/cell_lists/dictionary.jl
+++ b/src/cell_lists/dictionary.jl
@@ -1,8 +1,8 @@
 """
-    DictionaryCellList{NDIMS}()
+    DictionaryCellList{T, NDIMS}()
 
 A simple cell list implementation where a cell index `(i, j)` or `(i, j, k)` is mapped to a
-`Vector{Int}` by a `Dict`.
+`Vector{T}` by a `Dict`.
 By using a dictionary, which only stores non-empty cells, the domain is
 potentially infinite.
 
@@ -11,17 +11,19 @@ for integer tuples, nor does it use a contiguous memory layout.
 Consequently, this cell list is not GPU-compatible.
 
 # Arguments
+- `T`: Either an `Integer` type, or `PointWithCoordinates{NDIMS, ELTYPE}`.
+       See [`PointWithCoordinates`](@ref) for more details.
 - `NDIMS`: Number of dimensions.
 """
-struct DictionaryCellList{NDIMS} <: AbstractCellList
-    hashtable    :: Dict{NTuple{NDIMS, Int}, Vector{Int}}
-    empty_vector :: Vector{Int} # Just an empty vector (used in `eachneighbor`)
+struct DictionaryCellList{T, NDIMS} <: AbstractCellList{T}
+    hashtable    :: Dict{NTuple{NDIMS, Int}, Vector{T}}
+    empty_vector :: Vector{T} # Just an empty vector (used in `getindex`)
 
-    function DictionaryCellList{NDIMS}() where {NDIMS}
-        hashtable = Dict{NTuple{NDIMS, Int}, Vector{Int}}()
-        empty_vector = Int[]
+    function DictionaryCellList{T, NDIMS}() where {T, NDIMS}
+        hashtable = Dict{NTuple{NDIMS, Int}, Vector{T}}()
+        empty_vector = T[]
 
-        new{NDIMS}(hashtable, empty_vector)
+        new{T, NDIMS}(hashtable, empty_vector)
     end
 end
 
@@ -80,9 +82,9 @@ end
     return cell_coords == cell_index
 end
 
-@inline index_type(::DictionaryCellList{NDIMS}) where {NDIMS} = NTuple{NDIMS, Int}
+@inline index_type(::DictionaryCellList{<:Any, NDIMS}) where {NDIMS} = NTuple{NDIMS, Int}
 
-function copy_cell_list(::DictionaryCellList{NDIMS}, search_radius,
-                        periodic_box) where {NDIMS}
-    return DictionaryCellList{NDIMS}()
+function copy_cell_list(::DictionaryCellList{T, NDIMS}, search_radius,
+                        periodic_box) where {T, NDIMS}
+    return DictionaryCellList{T, NDIMS}()
 end


### PR DESCRIPTION
I realized that the `FullGridCellList` (at least with the `Vector{Vector}` backend) is algorithmically almost identical to the method of CellListMap.jl. But CellListMap.jl is slightly faster on a single thread or on multiple threads when modified to use Polyester.jl for threading.

The main difference is that @lmiq is storing the coordinates together with the point indices in the cell lists. This avoids unordered access of the big coordinate array to get the coordinates of the neighbor.
I implemented a similar data structure and made it configurable, as our goal is to have a playground to try out methods.

We now get very similar performance to CellListMap.jl.
Here is a plot showing the speedup against CellListMap.jl on a single thread (Threadripper 3990X):
<img width="883" alt="grafik" src="https://github.com/trixi-framework/PointNeighbors.jl/assets/44124897/556061bf-14ee-457e-930d-a52553825662">
On 128 threads, we're still slightly slower:
<img width="885" alt="grafik" src="https://github.com/trixi-framework/PointNeighbors.jl/assets/44124897/ff8b368c-6ba0-4bdc-873c-29e0f77c9cdf">

Here is a plot showing the speedup from using `PointWithCoordinates` on different architectures.
<img width="728" alt="grafik" src="https://github.com/trixi-framework/PointNeighbors.jl/assets/44124897/5d035366-bf31-45ea-9be5-15a867ac46da">
We see the largest speedups (14-15% for a WCSPH interaction on 128 threads!) on the CPU. The Nvidia H100 is also benefiting from this data structure. The RTX 3090 is only getting 0.5-1% faster. For some reason, the AMD Instinct MI210 doesn't like this data structure at all and is performing 2x slower.