### PR TITLE
Avoid bounds checking where it is safe to do so

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Adapt = "3, 4"
 Atomix = "0.1"
-GPUArraysCore = "0.1"
+GPUArraysCore = "0.1, 0.2"
 KernelAbstractions = "0.9"
 LinearAlgebra = "1"
 Polyester = "0.7.5"

--- a/src/PointNeighbors.jl
+++ b/src/PointNeighbors.jl
@@ -4,6 +4,7 @@ using Reexport: @reexport
 
 using Adapt: Adapt
 using Atomix: Atomix
+using Base: @propagate_inbounds
 using GPUArraysCore: AbstractGPUArray
 using KernelAbstractions: KernelAbstractions, @kernel, @index
 using LinearAlgebra: dot

--- a/src/cell_lists/full_grid.jl
+++ b/src/cell_lists/full_grid.jl
@@ -156,7 +156,7 @@ function each_cell_index(cell_list::FullGridCellList{Nothing})
     error("`search_radius` is not defined for this cell list")
 end
 
-@inline function cell_index(cell_list::FullGridCellList, cell::Tuple)
+@propagate_inbounds function cell_index(cell_list::FullGridCellList, cell::Tuple)
     (; linear_indices) = cell_list
 
     return linear_indices[cell...]
@@ -164,7 +164,7 @@ end
 
 @inline cell_index(::FullGridCellList, cell::Integer) = cell
 
-@inline function Base.getindex(cell_list::FullGridCellList, cell)
+@propagate_inbounds function Base.getindex(cell_list::FullGridCellList, cell)
     (; cells) = cell_list
 
     return cells[cell_index(cell_list, cell)]

--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -164,8 +164,13 @@ end
 
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points, parallel::Val{true})
+    # Explicit bounds check before the hot loop (or GPU kernel)
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+
     @threaded system_coords for point in points
-        foreach_neighbor(f, system_coords, neighbor_coords, neighborhood_search, point)
+        # Now we can assume that `point` is inbounds
+        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
+                                   neighborhood_search, point)
     end
 
     return nothing
@@ -175,8 +180,13 @@ end
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points,
                                         backend::ParallelizationBackend)
+    # Explicit bounds check before the hot loop (or GPU kernel)
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+
     @threaded backend for point in points
-        foreach_neighbor(f, system_coords, neighbor_coords, neighborhood_search, point)
+        # Now we can assume that `point` is inbounds
+        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
+                                   neighborhood_search, point)
     end
 
     return nothing
@@ -184,8 +194,13 @@ end
 
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points, parallel::Val{false})
+    # Explicit bounds check before the hot loop
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+
     for point in points
-        foreach_neighbor(f, system_coords, neighbor_coords, neighborhood_search, point)
+        # Now we can assume that `point` is inbounds
+        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
+                                   neighborhood_search, point)
     end
 
     return nothing

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -345,7 +345,7 @@ end
     # a `@boundscheck` by calling this function with `@inbounds` because it has a kwarg.
     # We have to use `@propagate_inbounds`, which will also remove boundschecks
     # in the neighbor loop, which is not safe (see comment below).
-    # To avoid this, we have to use a functio barrier to disable the `@inbounds` again.
+    # To avoid this, we have to use a function barrier to disable the `@inbounds` again.
     point_coords = extract_svector(system_coords, Val(ndims(neighborhood_search)), point)
 
     __foreach_neighbor(f, system_coords, neighbor_system_coords, neighborhood_search,

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -366,7 +366,7 @@ end
         for neighbor_ in eachindex(neighbors)
             neighbor = @inbounds neighbors[neighbor_]
 
-            # Making the following `@inbounds` yields a ~3% speedup on an NVIDIA H100.
+            # Making the following `@inbounds` yields a ~2% speedup on an NVIDIA H100.
             # But we don't know if `neighbor` (extracted from the cell list) is in bounds.
             neighbor_coords = extract_svector(neighbor_system_coords,
                                               Val(ndims(neighborhood_search)), neighbor)

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -361,8 +361,11 @@ end
 
     for neighbor_cell_ in neighboring_cells(cell, neighborhood_search)
         neighbor_cell = Tuple(neighbor_cell_)
+        neighbors = points_in_cell(neighbor_cell, neighborhood_search)
 
-        for neighbor in points_in_cell(neighbor_cell, neighborhood_search)
+        for neighbor_ in eachindex(neighbors)
+            neighbor = @inbounds neighbors[neighbor_]
+
             # Making the following `@inbounds` yields a ~3% speedup on an NVIDIA H100.
             # But we don't know if `neighbor` (extracted from the cell list) is in bounds.
             neighbor_coords = extract_svector(neighbor_system_coords,
@@ -402,7 +405,7 @@ end
                       for cell in neighboring_cells(cell, neighborhood_search))
 end
 
-@inline function points_in_cell(cell_index, neighborhood_search)
+@propagate_inbounds function points_in_cell(cell_index, neighborhood_search)
     (; cell_list) = neighborhood_search
 
     return cell_list[periodic_cell_index(cell_index, neighborhood_search)]

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,9 +1,10 @@
 # Return the `i`-th column of the array `A` as an `SVector`.
 @inline function extract_svector(A, ::Val{NDIMS}, i) where {NDIMS}
-    # Inlining this makes the WCSPH benchmark ~8% faster on an H100 GPU.
-    # Even when adding an explicit bounds check before, it is still ~4% faster.
-    # However, inlining makes it ~25% slower on an RTX 3090.
-    return SVector(ntuple(@inline(dim -> A[dim, i]), NDIMS))
+    # Explicit bounds check, which can be removed by calling this function with `@inbounds`
+    @boundscheck checkbounds(A, NDIMS, i)
+
+    # Assume inbounds access now
+    return SVector(ntuple(@inline(dim -> @inbounds A[dim, i]), NDIMS))
 end
 
 # When particles end up with coordinates so big that the cell coordinates

--- a/src/vector_of_vectors.jl
+++ b/src/vector_of_vectors.jl
@@ -26,9 +26,10 @@ end
 @inline function Base.getindex(vov::DynamicVectorOfVectors, i)
     (; backend, lengths) = vov
 
+    # This is slightly faster than without explicit boundscheck and `@inbounds` below
     @boundscheck checkbounds(vov, i)
 
-    return view(backend, 1:lengths[i], i)
+    return @inbounds view(backend, 1:lengths[i], i)
 end
 
 @inline function Base.push!(vov::DynamicVectorOfVectors, vector::AbstractVector)


### PR DESCRIPTION
This PR and https://github.com/trixi-framework/TrixiParticles.jl/pull/656 yield a ~3% speedup on a Threadripper 3990X and a ~42% speedup on an Nvidia H100. Interestingly, there is no difference on an Nvidia RTX 3090 with FP64 (probably limited by something else), but it benefits even more from inbounds on FP32 with a 60% speedup.

<img width="867" alt="grafik" src="https://github.com/user-attachments/assets/35b60faf-acbc-4197-b417-9b2643ac9d0d">

Not all bounds checks could be safely removed. See #79 for a completely exception-free kernel. The additional speedup is about 2% and can be neglected.