### PR TITLE
[Proof of Concept] Remove all exceptions from fluid-fluid kernel

### DIFF
--- a/src/PointNeighbors.jl
+++ b/src/PointNeighbors.jl
@@ -4,6 +4,7 @@ using Reexport: @reexport
 
 using Adapt: Adapt
 using Atomix: Atomix
+using Base: @propagate_inbounds
 using GPUArraysCore: AbstractGPUArray
 using KernelAbstractions: KernelAbstractions, @kernel, @index
 using LinearAlgebra: dot

--- a/src/cell_lists/full_grid.jl
+++ b/src/cell_lists/full_grid.jl
@@ -156,7 +156,7 @@ function each_cell_index(cell_list::FullGridCellList{Nothing})
     error("`search_radius` is not defined for this cell list")
 end
 
-@inline function cell_index(cell_list::FullGridCellList, cell::Tuple)
+@propagate_inbounds function cell_index(cell_list::FullGridCellList, cell::Tuple)
     (; linear_indices) = cell_list
 
     return linear_indices[cell...]
@@ -164,7 +164,7 @@ end
 
 @inline cell_index(::FullGridCellList, cell::Integer) = cell
 
-@inline function Base.getindex(cell_list::FullGridCellList, cell)
+@propagate_inbounds function Base.getindex(cell_list::FullGridCellList, cell)
     (; cells) = cell_list
 
     return cells[cell_index(cell_list, cell)]

--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -164,8 +164,13 @@ end
 
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points, parallel::Val{true})
+    # Explicit bounds check before the hot loop (or GPU kernel)
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+
     @threaded system_coords for point in points
-        foreach_neighbor(f, system_coords, neighbor_coords, neighborhood_search, point)
+        # Now we can assume that `point` is inbounds
+        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
+                                   neighborhood_search, point)
     end
 
     return nothing
@@ -175,8 +180,13 @@ end
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points,
                                         backend::ParallelizationBackend)
+    # Explicit bounds check before the hot loop (or GPU kernel)
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+
     @threaded backend for point in points
-        foreach_neighbor(f, system_coords, neighbor_coords, neighborhood_search, point)
+        # Now we can assume that `point` is inbounds
+        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
+                                   neighborhood_search, point)
     end
 
     return nothing
@@ -184,8 +194,13 @@ end
 
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points, parallel::Val{false})
+    # Explicit bounds check before the hot loop
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+
     for point in points
-        foreach_neighbor(f, system_coords, neighbor_coords, neighborhood_search, point)
+        # Now we can assume that `point` is inbounds
+        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
+                                   neighborhood_search, point)
     end
 
     return nothing

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -361,14 +361,14 @@ end
 
     for neighbor_cell_ in neighboring_cells(cell, neighborhood_search)
         neighbor_cell = Tuple(neighbor_cell_)
-        neighbors = points_in_cell(neighbor_cell, neighborhood_search)
+        neighbors = @inbounds points_in_cell(neighbor_cell, neighborhood_search)
 
         for neighbor_ in eachindex(neighbors)
             neighbor = @inbounds neighbors[neighbor_]
 
             # Making the following `@inbounds` yields a ~2% speedup on an NVIDIA H100.
             # But we don't know if `neighbor` (extracted from the cell list) is in bounds.
-            neighbor_coords = extract_svector(neighbor_system_coords,
+            neighbor_coords = @inbounds extract_svector(neighbor_system_coords,
                                               Val(ndims(neighborhood_search)), neighbor)
 
             pos_diff = point_coords - neighbor_coords

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -366,7 +366,7 @@ end
         for neighbor_ in eachindex(neighbors)
             neighbor = @inbounds neighbors[neighbor_]
 
-            # Making the following `@inbounds` yields a ~3% speedup on an NVIDIA H100.
+            # Making the following `@inbounds` yields a ~2% speedup on an NVIDIA H100.
             # But we don't know if `neighbor` (extracted from the cell list) is in bounds.
             neighbor_coords = extract_svector(neighbor_system_coords,
                                               Val(ndims(neighborhood_search)), neighbor)

--- a/src/nhs_grid.jl
+++ b/src/nhs_grid.jl
@@ -361,8 +361,11 @@ end
 
     for neighbor_cell_ in neighboring_cells(cell, neighborhood_search)
         neighbor_cell = Tuple(neighbor_cell_)
+        neighbors = points_in_cell(neighbor_cell, neighborhood_search)
 
-        for neighbor in points_in_cell(neighbor_cell, neighborhood_search)
+        for neighbor_ in eachindex(neighbors)
+            neighbor = @inbounds neighbors[neighbor_]
+
             # Making the following `@inbounds` yields a ~3% speedup on an NVIDIA H100.
             # But we don't know if `neighbor` (extracted from the cell list) is in bounds.
             neighbor_coords = extract_svector(neighbor_system_coords,
@@ -402,7 +405,7 @@ end
                       for cell in neighboring_cells(cell, neighborhood_search))
 end
 
-@inline function points_in_cell(cell_index, neighborhood_search)
+@propagate_inbounds function points_in_cell(cell_index, neighborhood_search)
     (; cell_list) = neighborhood_search
 
     return cell_list[periodic_cell_index(cell_index, neighborhood_search)]

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,9 +1,10 @@
 # Return the `i`-th column of the array `A` as an `SVector`.
 @inline function extract_svector(A, ::Val{NDIMS}, i) where {NDIMS}
-    # Inlining this makes the WCSPH benchmark ~8% faster on an H100 GPU.
-    # Even when adding an explicit bounds check before, it is still ~4% faster.
-    # However, inlining makes it ~25% slower on an RTX 3090.
-    return SVector(ntuple(@inline(dim -> A[dim, i]), NDIMS))
+    # Explicit bounds check, which can be removed by calling this function with `@inbounds`
+    @boundscheck checkbounds(A, NDIMS, i)
+
+    # Assume inbounds access now
+    return SVector(ntuple(@inline(dim -> @inbounds A[dim, i]), NDIMS))
 end
 
 # When particles end up with coordinates so big that the cell coordinates

--- a/src/vector_of_vectors.jl
+++ b/src/vector_of_vectors.jl
@@ -26,9 +26,10 @@ end
 @inline function Base.getindex(vov::DynamicVectorOfVectors, i)
     (; backend, lengths) = vov
 
+    # This is slightly faster than without explicit boundscheck and `@inbounds` below
     @boundscheck checkbounds(vov, i)
 
-    return view(backend, 1:lengths[i], i)
+    return @inbounds view(backend, 1:lengths[i], i)
 end
 
 @inline function Base.push!(vov::DynamicVectorOfVectors, vector::AbstractVector)


### PR DESCRIPTION
With these remaining two `@inbounds`, the resulting device code does not contain any exceptions.
However, the WCSPH benchmark is only 2% faster on an Nvidia H100, and these two `@inbounds` are not safe, so there is no reason to do this.
This PR is just a reference to evaluate the impact of the remaining exceptions and is not meant to be merged.