### PR TITLE
[Hotfix] Fix boundscheck for `foreach_point_neighbor`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PointNeighbors"
 uuid = "1c4d5385-0a27-49de-8e2c-43b175c8985c"
 authors = ["Erik Faulhaber <erik.faulhaber@uni-koeln.de>"]
-version = "0.4.7-dev"
+version = "0.4.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -165,7 +165,7 @@ end
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points, parallel::Val{true})
     # Explicit bounds check before the hot loop (or GPU kernel)
-    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search), points)
 
     @threaded system_coords for point in points
         # Now we can assume that `point` is inbounds
@@ -181,7 +181,7 @@ end
                                         neighborhood_search, points,
                                         backend::ParallelizationBackend)
     # Explicit bounds check before the hot loop (or GPU kernel)
-    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search), points)
 
     @threaded backend for point in points
         # Now we can assume that `point` is inbounds
@@ -195,7 +195,7 @@ end
 @inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
                                         neighborhood_search, points, parallel::Val{false})
     # Explicit bounds check before the hot loop
-    @boundscheck checkbounds(system_coords, ndims(neighborhood_search))
+    @boundscheck checkbounds(system_coords, ndims(neighborhood_search), points)
 
     for point in points
         # Now we can assume that `point` is inbounds


### PR DESCRIPTION
This bug has two implications:
1. Bounds are not checked correctly, which might cause unchecked out-of-bounds access.
2. Bounds check fails when `points` is empty.