### PR TITLE
Add full support for parallelization backends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PointNeighbors"
 uuid = "1c4d5385-0a27-49de-8e2c-43b175c8985c"
 authors = ["Erik Faulhaber <erik.faulhaber@uni-koeln.de>"]
-version = "0.5"
+version = "0.4.9-dev"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/benchmarks/count_neighbors.jl
+++ b/benchmarks/count_neighbors.jl
@@ -12,18 +12,20 @@ implementations are highlighted. On the other hand, this is the least realistic 
 
 For a computationally heavier benchmark, see [`benchmark_n_body`](@ref).
 """
-function benchmark_count_neighbors(neighborhood_search, coordinates; parallel = true)
+function benchmark_count_neighbors(neighborhood_search, coordinates;
+                                   parallelization_backend = default_backend(coordinates))
     n_neighbors = zeros(Int, size(coordinates, 2))
 
-    function count_neighbors!(n_neighbors, coordinates, neighborhood_search, parallel)
+    function count_neighbors!(n_neighbors, coordinates, neighborhood_search,
+                              parallelization_backend)
         n_neighbors .= 0
 
-        foreach_point_neighbor(coordinates, coordinates, neighborhood_search,
-                               parallel = parallel) do i, _, _, _
+        foreach_point_neighbor(coordinates, coordinates, neighborhood_search;
+                               parallelization_backend) do i, _, _, _
             n_neighbors[i] += 1
         end
     end
 
     return @belapsed $count_neighbors!($n_neighbors, $coordinates,
-                                       $neighborhood_search, $parallel)
+                                       $neighborhood_search, $parallelization_backend)
 end

--- a/benchmarks/n_body.jl
+++ b/benchmarks/n_body.jl
@@ -26,7 +26,7 @@ function benchmark_n_body(neighborhood_search, coordinates_;
 
     dv = similar(coordinates)
 
-    function compute_acceleration!(dv, coordinates, mass, G, neighborhood_search;
+    function compute_acceleration!(dv, coordinates, mass, G, neighborhood_search,
                                    parallelization_backend)
         dv .= 0.0
 

--- a/benchmarks/n_body.jl
+++ b/benchmarks/n_body.jl
@@ -12,12 +12,13 @@ This is a more realistic benchmark for particle-based simulations than
 However, due to the higher computational cost, differences between neighborhood search
 implementations are less pronounced.
 """
-function benchmark_n_body(neighborhood_search, coordinates_; parallel = true)
+function benchmark_n_body(neighborhood_search, coordinates_;
+                          parallelization_backend = default_backend(coordinates_))
     # Passing a different backend like `CUDA.CUDABackend`
     # allows us to change the type of the array to run the benchmark on the GPU.
     # Passing `parallel = true` or `parallel = false` will not change anything here.
-    coordinates = PointNeighbors.Adapt.adapt(parallel, coordinates_)
-    nhs = PointNeighbors.Adapt.adapt(parallel, neighborhood_search)
+    coordinates = PointNeighbors.Adapt.adapt(parallelization_backend, coordinates_)
+    nhs = PointNeighbors.Adapt.adapt(parallelization_backend, neighborhood_search)
 
     # This preserves the data type of `coordinates`, which makes it work for GPU types
     mass = 1e10 * (rand!(similar(coordinates, size(coordinates, 2))) .+ 1)
@@ -25,11 +26,12 @@ function benchmark_n_body(neighborhood_search, coordinates_; parallel = true)
 
     dv = similar(coordinates)
 
-    function compute_acceleration!(dv, coordinates, mass, G, neighborhood_search, parallel)
+    function compute_acceleration!(dv, coordinates, mass, G, neighborhood_search;
+                                   parallelization_backend)
         dv .= 0.0
 
-        foreach_point_neighbor(coordinates, coordinates, neighborhood_search,
-                               parallel = parallel) do i, j, pos_diff, distance
+        foreach_point_neighbor(coordinates, coordinates, neighborhood_search;
+                               parallelization_backend) do i, j, pos_diff, distance
             # Only consider particles with a distance > 0
             distance < sqrt(eps()) && return
 
@@ -43,5 +45,6 @@ function benchmark_n_body(neighborhood_search, coordinates_; parallel = true)
         return dv
     end
 
-    return @belapsed $compute_acceleration!($dv, $coordinates, $mass, $G, $nhs, $parallel)
+    return @belapsed $compute_acceleration!($dv, $coordinates, $mass, $G, $nhs,
+                                            $parallelization_backend)
 end

--- a/benchmarks/plot.jl
+++ b/benchmarks/plot.jl
@@ -36,7 +36,7 @@ include("benchmarks/benchmarks.jl")
 plot_benchmarks(benchmark_count_neighbors, (10, 10), 3)
 """
 function plot_benchmarks(benchmark, n_points_per_dimension, iterations;
-                         parallel = true, title = "",
+                         parallelization_backend = PolyesterBackend(), title = "",
                          seed = 1, perturbation_factor_position = 1.0)
     neighborhood_searches_names = ["TrivialNeighborhoodSearch";;
                                    "GridNeighborhoodSearch";;
@@ -69,7 +69,7 @@ function plot_benchmarks(benchmark, n_points_per_dimension, iterations;
             neighborhood_search = neighborhood_searches[i]
             initialize!(neighborhood_search, coordinates, coordinates)
 
-            time = benchmark(neighborhood_search, coordinates, parallel = parallel)
+            time = benchmark(neighborhood_search, coordinates; parallelization_backend)
             times[iter, i] = time
             time_string = BenchmarkTools.prettytime(time * 1e9)
             println("$(neighborhood_searches_names[i])")

--- a/benchmarks/smoothed_particle_hydrodynamics.jl
+++ b/benchmarks/smoothed_particle_hydrodynamics.jl
@@ -9,7 +9,8 @@ A benchmark of the right-hand side of a full real-life Weakly Compressible
 Smoothed Particle Hydrodynamics (WCSPH) simulation with TrixiParticles.jl.
 This method is used to simulate an incompressible fluid.
 """
-function benchmark_wcsph(neighborhood_search, coordinates; parallel = true)
+function benchmark_wcsph(neighborhood_search, coordinates;
+                         parallelization_backend = default_backend(coordinates))
     density = 1000.0
     fluid = InitialCondition(; coordinates, density, mass = 0.1)
 
@@ -34,19 +35,12 @@ function benchmark_wcsph(neighborhood_search, coordinates; parallel = true)
                                                smoothing_length, viscosity = viscosity,
                                                density_diffusion = density_diffusion)
 
-    # Note that we cannot just disable parallelism in TrixiParticles.
-    # But passing a different backend like `CUDA.CUDABackend`
-    # allows us to change the type of the array to run the benchmark on the GPU.
-    if parallel isa Bool
-        system = fluid_system
-        nhs = neighborhood_search
-    else
-        system = PointNeighbors.Adapt.adapt(parallel, fluid_system)
-        nhs = PointNeighbors.Adapt.adapt(parallel, neighborhood_search)
-    end
+    system = PointNeighbors.Adapt.adapt(parallelization_backend, fluid_system)
+    nhs = PointNeighbors.Adapt.adapt(parallelization_backend, neighborhood_search)
 
-    v = PointNeighbors.Adapt.adapt(parallel, vcat(fluid.velocity, fluid.density'))
-    u = PointNeighbors.Adapt.adapt(parallel, coordinates)
+    v = PointNeighbors.Adapt.adapt(parallelization_backend,
+                                   vcat(fluid.velocity, fluid.density'))
+    u = PointNeighbors.Adapt.adapt(parallelization_backend, coordinates)
     dv = zero(v)
 
     # Initialize the system
@@ -61,7 +55,8 @@ end
 
 Like [`benchmark_wcsph`](@ref), but using single precision floating point numbers.
 """
-function benchmark_wcsph_fp32(neighborhood_search, coordinates_; parallel = true)
+function benchmark_wcsph_fp32(neighborhood_search, coordinates_;
+                              parallelization_backend = default_backend(coordinates_))
     coordinates = convert(Matrix{Float32}, coordinates_)
     density = 1000.0f0
     fluid = InitialCondition(; coordinates, density, mass = 0.1f0)
@@ -88,19 +83,12 @@ function benchmark_wcsph_fp32(neighborhood_search, coordinates_; parallel = true
                                                acceleration = (0.0f0, 0.0f0, 0.0f0),
                                                density_diffusion = density_diffusion)
 
-    # Note that we cannot just disable parallelism in TrixiParticles.
-    # But passing a different backend like `CUDA.CUDABackend`
-    # allows us to change the type of the array to run the benchmark on the GPU.
-    if parallel isa Bool
-        system = fluid_system
-        nhs = neighborhood_search
-    else
-        system = PointNeighbors.Adapt.adapt(parallel, fluid_system)
-        nhs = PointNeighbors.Adapt.adapt(parallel, neighborhood_search)
-    end
+    system = PointNeighbors.Adapt.adapt(parallelization_backend, fluid_system)
+    nhs = PointNeighbors.Adapt.adapt(parallelization_backend, neighborhood_search)
 
-    v = PointNeighbors.Adapt.adapt(parallel, vcat(fluid.velocity, fluid.density'))
-    u = PointNeighbors.Adapt.adapt(parallel, coordinates)
+    v = PointNeighbors.Adapt.adapt(parallelization_backend,
+                                   vcat(fluid.velocity, fluid.density'))
+    u = PointNeighbors.Adapt.adapt(parallelization_backend, coordinates)
     dv = zero(v)
 
     # Initialize the system
@@ -117,7 +105,8 @@ A benchmark of the right-hand side of a full real-life Total Lagrangian
 Smoothed Particle Hydrodynamics (TLSPH) simulation with TrixiParticles.jl.
 This method is used to simulate an elastic structure.
 """
-function benchmark_tlsph(neighborhood_search, coordinates; parallel = true)
+function benchmark_tlsph(neighborhood_search, coordinates;
+                         parallelization_backend = default_backend(coordinates))
     material = (density = 1000.0, E = 1.4e6, nu = 0.4)
     solid = InitialCondition(; coordinates, density = material.density, mass = 0.1)
 

--- a/benchmarks/update.jl
+++ b/benchmarks/update.jl
@@ -9,7 +9,8 @@ include("../test/point_cloud.jl")
 
 Benchmark neighborhood search initialization with the given `coordinates`.
 """
-function benchmark_initialize(neighborhood_search, coordinates; parallel = true)
+function benchmark_initialize(neighborhood_search, coordinates;
+                              parallelization_backend = default_backend(coordinates))
     return @belapsed $initialize!($neighborhood_search, $coordinates, $coordinates)
 end
 
@@ -21,7 +22,8 @@ perturbed point clouds.
 
 This is a good benchmark for incremental updates, since most particles stay in their cells.
 """
-function benchmark_update_alternating(neighborhood_search, coordinates; parallel = true)
+function benchmark_update_alternating(neighborhood_search, coordinates;
+                                      parallelization_backend = default_backend(coordinates))
     coordinates2 = copy(coordinates)
     # Perturb all coordinates with a perturbation factor of `0.015`.
     # This factor was tuned so that ~0.5% of the particles change their cell during an

--- a/src/PointNeighbors.jl
+++ b/src/PointNeighbors.jl
@@ -11,8 +11,8 @@ using LinearAlgebra: dot
 using Polyester: Polyester
 @reexport using StaticArrays: SVector
 
-include("util.jl")
 include("vector_of_vectors.jl")
+include("util.jl")
 include("neighborhood_search.jl")
 include("nhs_trivial.jl")
 include("cell_lists/cell_lists.jl")
@@ -25,9 +25,9 @@ export TrivialNeighborhoodSearch, GridNeighborhoodSearch, PrecomputedNeighborhoo
 export DictionaryCellList, FullGridCellList
 export ParallelUpdate, SemiParallelUpdate, SerialIncrementalUpdate, SerialUpdate,
        ParallelIncrementalUpdate
-export requires_update, requires_resizing
+export requires_update
 export initialize!, update!, initialize_grid!, update_grid!
-export PolyesterBackend, ThreadsDynamicBackend, ThreadsStaticBackend
+export SerialBackend, PolyesterBackend, ThreadsDynamicBackend, ThreadsStaticBackend
 export PeriodicBox, copy_neighborhood_search
 
 end # module PointNeighbors

--- a/src/PointNeighbors.jl
+++ b/src/PointNeighbors.jl
@@ -27,7 +27,8 @@ export ParallelUpdate, SemiParallelUpdate, SerialIncrementalUpdate, SerialUpdate
        ParallelIncrementalUpdate
 export requires_update
 export initialize!, update!, initialize_grid!, update_grid!
-export SerialBackend, PolyesterBackend, ThreadsDynamicBackend, ThreadsStaticBackend
+export SerialBackend, PolyesterBackend, ThreadsDynamicBackend, ThreadsStaticBackend,
+       default_backend
 export PeriodicBox, copy_neighborhood_search
 
 end # module PointNeighbors

--- a/src/cell_lists/full_grid.jl
+++ b/src/cell_lists/full_grid.jl
@@ -126,7 +126,7 @@ function Base.empty!(cell_list::FullGridCellList)
     (; cells) = cell_list
 
     # `Base.empty!.(cells)`, but for all backends
-    for i in eachindex(cells)
+    @threaded default_backend(cells) for i in eachindex(cells)
         emptyat!(cells, i)
     end
 
@@ -223,6 +223,22 @@ function max_points_per_cell(cells)
 end
 
 @inline function check_cell_bounds(cell_list::FullGridCellList, cell::Tuple)
+    (; linear_indices) = cell_list
+
+    # Make sure that points are not added to the outer padding layer, which is needed
+    # to ensure that neighboring cells in all directions of all non-empty cells exist.
+    if !all(cell[i] in 2:(size(linear_indices, i) - 1) for i in eachindex(cell))
+        size_ = [2:(size(linear_indices, i) - 1) for i in eachindex(cell)]
+        print_size_ = "[$(join(size_, ", "))]"
+        error("particle coordinates are NaN or outside the domain bounds of the cell list\n" *
+              "cell $cell is out of bounds for cell grid of size $print_size_")
+    end
+end
+
+# On GPUs, we can't throw a proper error message because string interpolation is not allowed
+@inline function check_cell_bounds(cell_list::FullGridCellList{<:DynamicVectorOfVectors{<:Any,
+                                                                                        <:AbstractGPUArray}},
+                                   cell::Tuple)
     (; linear_indices) = cell_list
 
     # Make sure that points are not added to the outer padding layer, which is needed

--- a/src/gpu.jl
+++ b/src/gpu.jl
@@ -31,6 +31,3 @@ function Adapt.adapt_structure(to, nhs::GridNeighborhoodSearch)
     return GridNeighborhoodSearch(cell_list, search_radius, periodic_box, n_cells,
                                   cell_size, update_buffer, nhs.update_strategy)
 end
-
-# This is useful to pass the backend directly to `@threaded`
-KernelAbstractions.get_backend(backend::KernelAbstractions.Backend) = backend

--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -55,8 +55,8 @@ in this case to avoid unnecessary updates.
 The first flag in `points_moving` indicates if points in `x` are moving.
 The second flag indicates if points in `y` are moving.
 
-If the neighborhood search update supports parallelization, the keyword argument
-`parallelization_backend` can be used to specify the parallelization backend.
+If the neighborhood search type supports parallelization, the keyword argument
+`parallelization_backend` can be used to specify a parallelization backend.
 See [`@threaded`](@ref) for a list of available backends.
 
 See also [`initialize!`](@ref).

--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -23,8 +23,8 @@ all points in `y` whose distances to that point are smaller than the search radi
 `x` and `y` are expected to be matrices, where the `i`-th column contains the coordinates
 of point `i`. Note that `x` and `y` can be identical.
 
-If the neighborhood search initialization supports parallelization, the keyword argument
-`parallelization_backend` can be used to specify the parallelization backend.
+If the neighborhood search type supports parallelization, the keyword argument
+`parallelization_backend` can be used to specify a parallelization backend.
 See [`@threaded`](@ref) for a list of available backends.
 
 See also [`update!`](@ref).

--- a/src/neighborhood_search.jl
+++ b/src/neighborhood_search.jl
@@ -13,17 +13,8 @@ function requires_update(::AbstractNeighborhoodSearch)
 end
 
 """
-    requires_resizing(search::AbstractNeighborhoodSearch)
-
-Returns `false` if the neighborhood search can be updated with a different number
-of neighbor points (`y`) without re-initializing it.
-"""
-function requires_resizing(::AbstractNeighborhoodSearch)
-    error("`requires_resizing` not implemented for this neighborhood search.")
-end
-
-"""
-    initialize!(search::AbstractNeighborhoodSearch, x, y)
+    initialize!(search::AbstractNeighborhoodSearch, x, y;
+                parallelization_backend = default_backend(x))
 
 Initialize a neighborhood search with the two coordinate arrays `x` and `y`.
 
@@ -32,19 +23,27 @@ all points in `y` whose distances to that point are smaller than the search radi
 `x` and `y` are expected to be matrices, where the `i`-th column contains the coordinates
 of point `i`. Note that `x` and `y` can be identical.
 
+If the neighborhood search initialization supports parallelization, the keyword argument
+`parallelization_backend` can be used to specify the parallelization backend.
+See [`@threaded`](@ref) for a list of available backends.
+
 See also [`update!`](@ref).
 """
-@inline initialize!(search::AbstractNeighborhoodSearch, x, y) = search
+@inline function initialize!(search::AbstractNeighborhoodSearch, x, y;
+                             parallelization_backend = default_backend(x))
+    return search
+end
 
 """
-    update!(search::AbstractNeighborhoodSearch, x, y; points_moving = (true, true))
+    update!(search::AbstractNeighborhoodSearch, x, y; points_moving = (true, true),
+            parallelization_backend = default_backend(x))
 
 Update an already initialized neighborhood search with the two coordinate arrays `x` and `y`.
 
-Like [`initialize!`](@ref), but reusing the existing data structures of the already
-initialized neighborhood search.
+Like [`initialize!`](@ref), but potentially reusing the existing data structures
+of the already initialized neighborhood search.
 When the points only moved a small distance since the last `update!` or `initialize!`,
-this is significantly faster than `initialize!`.
+this can be significantly faster than `initialize!`.
 
 Not all implementations support incremental updates.
 If incremental updates are not possible for an implementation, `update!` will fall back
@@ -56,20 +55,15 @@ in this case to avoid unnecessary updates.
 The first flag in `points_moving` indicates if points in `x` are moving.
 The second flag indicates if points in `y` are moving.
 
-!!! warning "Experimental Feature: Backend Specification"
-    The keyword argument `parallelization_backend` allows users to specify the
-    multithreading backend. This feature is currently considered experimental!
-
-    Possible parallelization backends are:
-    - [`ThreadsDynamicBackend`](@ref) to use `Threads.@threads :dynamic`
-    - [`ThreadsStaticBackend`](@ref) to use `Threads.@threads :static`
-    - [`PolyesterBackend`](@ref) to use `Polyester.@batch`
-    - `KernelAbstractions.Backend` to launch a GPU kernel
+If the neighborhood search update supports parallelization, the keyword argument
+`parallelization_backend` can be used to specify the parallelization backend.
+See [`@threaded`](@ref) for a list of available backends.
 
 See also [`initialize!`](@ref).
 """
 @inline function update!(search::AbstractNeighborhoodSearch, x, y;
-                         points_moving = (true, true), parallelization_backend = x)
+                         points_moving = (true, true),
+                         parallelization_backend = default_backend(x))
     return search
 end
 
@@ -129,7 +123,8 @@ end
 
 """
     foreach_point_neighbor(f, system_coords, neighbor_coords, neighborhood_search;
-                           points = axes(system_coords, 2), parallel = true)
+                           parallelization_backend = default_backend(system_coords),
+                           points = axes(system_coords, 2))
 
 Loop for each point in `system_coords` over all points in `neighbor_coords` whose distances
 to that point are smaller than the search radius and execute the function `f(i, j, pos_diff, d)`,
@@ -140,10 +135,12 @@ where
   (`system_coords[:, i]`) and ``y`` the coordinates of the neighbor (`neighbor_coords[:, j]`),
 - `d` the distance between `x` and `y`.
 
-The `neighborhood_search` must have been initialized or updated with `system_coords`
-as first coordinate array and `neighbor_coords` as second coordinate array.
-
 Note that `system_coords` and `neighbor_coords` can be identical.
+
+!!! warning
+    The `neighborhood_search` must have been initialized or updated with `system_coords`
+    as first coordinate array and `neighbor_coords` as second coordinate array.
+    This can be skipped for certain implementations. See [`requires_update`](@ref).
 
 # Arguments
 - `f`: The function explained above.
@@ -155,70 +152,26 @@ Note that `system_coords` and `neighbor_coords` can be identical.
 
 # Keywords
 - `points`: Loop over these point indices. By default all columns of `system_coords`.
-- `parallel=true`: Run the outer loop over `points` thread-parallel.
+- `parallelization_backend`: Run the outer loop over `points` in parallel with the
+                             specified backend. By default, the backend is selected
+                             automatically based on the type of `system_coords`.
+                             See [`@threaded`](@ref) for a list of available backends.
 
 See also [`initialize!`](@ref), [`update!`](@ref).
 """
 function foreach_point_neighbor(f::T, system_coords, neighbor_coords, neighborhood_search;
-                                parallel::Union{Bool, ParallelizationBackend} = true,
+                                parallelization_backend::ParallelizationBackend = default_backend(system_coords),
                                 points = axes(system_coords, 2)) where {T}
     # The type annotation above is to make Julia specialize on the type of the function.
     # Otherwise, unspecialized code will cause a lot of allocations
     # and heavily impact performance.
     # See https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing
-    if parallel isa Bool
-        # When `false` is passed, run serially. When `true` is passed, run either a
-        # threaded loop with `Polyester.@batch`, or, when `system_coords` is a GPU array,
-        # launch the loop as a kernel on the GPU.
-        parallel_ = Val(parallel)
-    elseif parallel isa ParallelizationBackend
-        # When a `KernelAbstractions.Backend` is passed, launch the loop as a GPU kernel
-        # on this backend. This is useful to test the GPU code on the CPU by passing
-        # `parallel = KernelAbstractions.CPU()`, even though `system_coords isa Array`.
-        parallel_ = parallel
-    end
 
-    foreach_point_neighbor(f, system_coords, neighbor_coords, neighborhood_search, points,
-                           parallel_)
-end
-
-@inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
-                                        neighborhood_search, points, parallel::Val{true})
     # Explicit bounds check before the hot loop (or GPU kernel)
     @boundscheck checkbounds(system_coords, ndims(neighborhood_search), points)
 
-    @threaded system_coords for point in points
-        # Now we can assume that `point` is inbounds
-        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
-                                   neighborhood_search, point)
-    end
-
-    return nothing
-end
-
-# When a `KernelAbstractions.Backend` is passed, launch a GPU kernel on this backend
-@inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
-                                        neighborhood_search, points,
-                                        backend::ParallelizationBackend)
-    # Explicit bounds check before the hot loop (or GPU kernel)
-    @boundscheck checkbounds(system_coords, ndims(neighborhood_search), points)
-
-    @threaded backend for point in points
-        # Now we can assume that `point` is inbounds
-        @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
-                                   neighborhood_search, point)
-    end
-
-    return nothing
-end
-
-@inline function foreach_point_neighbor(f, system_coords, neighbor_coords,
-                                        neighborhood_search, points, parallel::Val{false})
-    # Explicit bounds check before the hot loop
-    @boundscheck checkbounds(system_coords, ndims(neighborhood_search), points)
-
-    for point in points
-        # Now we can assume that `point` is inbounds
+    @threaded parallelization_backend for point in points
+        # Now we can safely assume that `point` is inbounds
         @inbounds foreach_neighbor(f, system_coords, neighbor_coords,
                                    neighborhood_search, point)
     end

--- a/src/nhs_trivial.jl
+++ b/src/nhs_trivial.jl
@@ -32,12 +32,14 @@ end
 
 @inline requires_update(::TrivialNeighborhoodSearch) = (false, false)
 
-@inline requires_resizing(::TrivialNeighborhoodSearch) = false
-
-@inline initialize!(search::TrivialNeighborhoodSearch, x, y) = search
+@inline function initialize!(search::TrivialNeighborhoodSearch, x, y;
+                             parallelization_backend = default_backend(x))
+    return search
+end
 
 @inline function update!(search::TrivialNeighborhoodSearch, x, y;
-                         points_moving = (true, true), parallelization_backend = x)
+                         points_moving = (true, true),
+                         parallelization_backend = default_backend(x))
     return search
 end
 

--- a/test/cell_lists/full_grid.jl
+++ b/test/cell_lists/full_grid.jl
@@ -15,19 +15,18 @@
             nhs = GridNeighborhoodSearch{N}(; cell_list, search_radius)
             y = rand(N, 10)
             error_string = "particle coordinates are NaN or outside the domain bounds of the cell list"
-            error = ErrorException(error_string)
 
             y[1, 7] = NaN
-            @test_throws error initialize!(nhs, y, y)
+            @test_throws error_string initialize!(nhs, y, y)
 
             y[1, 7] = min_corner[1] - 0.01
-            @test_throws error initialize!(nhs, y, y)
+            @test_throws error_string initialize!(nhs, y, y)
 
             # A bit more than max corner might still be inside the grid,
             # but one search radius more is always outside.
             # Also accounting for 0.001 extra padding (see above).
             y[1, 7] = max_corner[1] + 1.01
-            @test_throws error initialize!(nhs, y, y)
+            @test_throws error_string initialize!(nhs, y, y)
 
             y[1, 7] = 0.0
             @test_nowarn_mod initialize!(nhs, y, y)
@@ -37,16 +36,16 @@
             @test_nowarn_mod update!(nhs, y, y)
 
             y[1, 7] = NaN
-            @test_throws error update!(nhs, y, y)
+            @test_throws error_string update!(nhs, y, y)
 
             # A bit more than max corner might still be inside the grid,
             # but one search radius more is always outside.
             # Also accounting for 0.001 extra padding (see above).
             y[1, 7] = max_corner[1] + 1.01
-            @test_throws error update!(nhs, y, y)
+            @test_throws error_string update!(nhs, y, y)
 
             y[1, 7] = min_corner[1] - 0.01
-            @test_throws error update!(nhs, y, y)
+            @test_throws error_string update!(nhs, y, y)
         end
     end
 end

--- a/test/neighborhood_search.jl
+++ b/test/neighborhood_search.jl
@@ -145,8 +145,10 @@
             neighbors_expected = [Int[] for _ in axes(coords, 2)]
 
             foreach_point_neighbor(coords, coords, trivial_nhs,
-                                   parallel = false) do point, neighbor,
-                                                        pos_diff, distance
+                                   parallelization_backend = SerialBackend()) do point,
+                                                                                 neighbor,
+                                                                                 pos_diff,
+                                                                                 distance
                 append!(neighbors_expected[point], neighbor)
             end
 
@@ -236,8 +238,10 @@
                 neighbors = [Int[] for _ in axes(coords, 2)]
 
                 foreach_point_neighbor(coords, coords, nhs,
-                                       parallel = false) do point, neighbor,
-                                                            pos_diff, distance
+                                       parallelization_backend = SerialBackend()) do point,
+                                                                                     neighbor,
+                                                                                     pos_diff,
+                                                                                     distance
                     append!(neighbors[point], neighbor)
                 end
 

--- a/test/nhs_grid.jl
+++ b/test/nhs_grid.jl
@@ -167,8 +167,7 @@
         coordinates2 = coordinates1 .+ [1.4, -3.5, 0.8]
 
         # Update neighborhood search
-        coords_fun2(i) = coordinates2[:, i]
-        update_grid!(nhs1, coords_fun2)
+        update_grid!(nhs1, coordinates2)
 
         # Get each neighbor for updated NHS
         neighbors2 = sort(collect(PointNeighbors.eachneighbor(point_position1, nhs1)))


### PR DESCRIPTION
- Added the `SerialBackend`.
- Changed `@threaded` API to only allow backends as first argument and not arrays. This is a breaking change.
- Added the kwarg `parallelization_backend` to `initialize!` and to docs (and removed experimental warning).
- Renamed the kwarg `parellel` of `foreach_point_neighbor` to `parallelization_backend` and removed support for booleans like `parallel = true`. This is a breaking change.
- Added better error message for `FullGridCellList` out of bounds (on CPUs only).
- Removed `requires_resizing` (@LasNikas requested it but didn't need it at the end). This is a breaking change.