### PR TITLE
added GraphNetSim.jl to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Benchmark of a full right-hand side evaluation of a WCSPH simulation (note the l
 - [TrixiParticles.jl](https://github.com/trixi-framework/TrixiParticles.jl)
 - [Peridynamics.jl](https://github.com/kaipartmann/Peridynamics.jl)
 - [PeriLab.jl](https://github.com/PeriHub/PeriLab.jl)
+- [GraphNetSim.jl](https://github.com/una-auxme/GraphNetSim.jl)
 
 If you're using PointNeighbors.jl in your package, please feel free to open a PR adding it
 to this list.


### PR DESCRIPTION
We would gladly add GraphNetSim.jl to your Readme.md as we use it as one of our graph construction backends in GraphNetSim.jl